### PR TITLE
fix(outputs): update output format for addons to list

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "addons" {
-  value = {
+  value = [{
     content = templatefile("${path.module}/addon_content.tpl", {
       secrets = [for s in data.aws_secretsmanager_secret_version.secret_version : jsondecode(s.secret_string)]
     })
     version = local.version
     name    = "argocd-cluster-secrets"
-  }
+  }]
 }


### PR DESCRIPTION
Change the output format of the "addons" variable from a map to a list  
to enhance consistency and facilitate easier iteration. This change  
ensures compatibility with other modules that expect a list structure.