### PR TITLE
chore: update refresh interval for secret synchronization

### DIFF
--- a/addon_content.tpl
+++ b/addon_content.tpl
@@ -7,7 +7,7 @@ metadata:
   labels:
     argocd.argoproj.io/secret-type: cluster
 spec:
-  refreshInterval: 30s
+  refreshInterval: 1h
   secretStoreRef:
     name: external-secrets
     kind: ClusterSecretStore


### PR DESCRIPTION
Change the refresh interval from 30 seconds to 1 hour in the 
addon_content.tpl file to reduce the frequency of secret 
synchronization. This improves performance and lowers the load 
on the external secrets management system.