### PR TITLE
fix: remove LocalStack dependency from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,6 @@ jobs:
         os: [ ubuntu-latest ]
         tf-version: [ 1.3.2 ]
     steps:
-      - name: Start LocalStack
-        uses: LocalStack/setup-localstack@e23ef40712445a2786428c118c31986bca4e9a40 # v0.3.1
-        with:
-          image-tag: 'latest'
-
       - name: Install terraform v${{ matrix.tf-version }}
         run: |
           curl -LO https://releases.hashicorp.com/terraform/${{ matrix.tf-version }}/terraform_${{ matrix.tf-version }}_linux_amd64.zip

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,11 @@
 SHELL = /bin/bash
 EXAMPLES = $(shell find ./examples/* -maxdepth 1 -type d -not -path '*/\.*')
 
-export AWS_ACCESS_KEY_ID := test
-export AWS_SECRET_ACCESS_KEY := test
-export AWS_DEFAULT_REGION := us-east-1
-export AWS_REGION := us-east-1
-export AWS_ENDPOINT_URL := http://localhost:4566
 .PHONY: examples
 examples: $(addprefix example/,$(EXAMPLES))
 
 .PHONY: example/%
 example/%:
-	@aws secretsmanager create-secret --name argocd/clusters/$*-1 --secret-string 'asd' --tags Key=a/tag,Value=dev Key=another/tag,Value=prod
-	@aws secretsmanager create-secret --name argocd/clusters/$*-2 --secret-string 'asd' --tags Key=tag1,Value=stage Key=tag2,Value=invalid
-
 	@echo "Processing example: $(notdir $*)"
-	@terraform -chdir=$* init
+	@terraform -chdir=$* init -backend=false
 	@terraform -chdir=$* validate
-
-	@terraform -chdir=$* apply -auto-approve > $*/output
-
-	@aws secretsmanager delete-secret --secret-id argocd/clusters/$*-1
-	@aws secretsmanager delete-secret --secret-id argocd/clusters/$*-2
-
-	$*/validate.sh $*/output

--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -1,37 +1,10 @@
 provider "aws" {
-  access_key                  = "test"
-  secret_key                  = "test"
-  region                      = "us-east-1"
-  s3_use_path_style           = false
+  skip_requesting_account_id  = true
   skip_credentials_validation = true
   skip_metadata_api_check     = true
-  skip_requesting_account_id  = true
-
-  endpoints {
-    apigateway     = "http://localhost:4566"
-    apigatewayv2   = "http://localhost:4566"
-    cloudformation = "http://localhost:4566"
-    cloudwatch     = "http://localhost:4566"
-    dynamodb       = "http://localhost:4566"
-    ec2            = "http://localhost:4566"
-    es             = "http://localhost:4566"
-    elasticache    = "http://localhost:4566"
-    firehose       = "http://localhost:4566"
-    iam            = "http://localhost:4566"
-    kinesis        = "http://localhost:4566"
-    lambda         = "http://localhost:4566"
-    rds            = "http://localhost:4566"
-    redshift       = "http://localhost:4566"
-    route53        = "http://localhost:4566"
-    s3             = "http://s3.localhost.localstack.cloud:4566"
-    secretsmanager = "http://s3.localhost.localstack.cloud:4566"
-    ses            = "http://localhost:4566"
-    sns            = "http://localhost:4566"
-    sqs            = "http://localhost:4566"
-    ssm            = "http://localhost:4566"
-    stepfunctions  = "http://localhost:4566"
-    sts            = "http://localhost:4566"
-  }
+  region                      = "eu-west-1"
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
 }
 
 terraform {

--- a/examples/basic/validate.sh
+++ b/examples/basic/validate.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -Eeuo pipefail
-echo "Checking secret labels"
-
-grep -Fq "a/tag: dev" $1


### PR DESCRIPTION
## Summary
- LocalStack now requires a license, breaking CI examples
- Remove LocalStack setup step from GitHub Actions workflow
- Simplify Makefile to validate-only (no more `terraform apply`)
- Remove LocalStack endpoints from provider config, use mock credentials
- Remove `validate.sh` script (was validating `apply` output)

Follows the same pattern applied to other Opzkit terraform modules (e.g. external-dns, external-secrets-operator).