### PR TITLE
feat: support bearerToken auth for non-AWS clusters

### DIFF
--- a/addon_content.tpl
+++ b/addon_content.tpl
@@ -33,6 +33,17 @@ spec:
                   "insecure": false
                 }
               }
+            {{- else if ne (index . "bearer_token") "" }}
+            name: "{{ .name }}"
+            server: "{{ .host }}"
+            config: |
+              {
+                "bearerToken": "{{ .bearer_token }}",
+                "tlsClientConfig": {
+                  "insecure": false,
+                  "caData": "{{ .cluster_ca_certificate }}"
+                }
+              }
             {{- else }}
             name: "{{ .name }}"
             server: "{{ .host }}"


### PR DESCRIPTION
## Summary

Extends the ExternalSecret template to handle clusters registered with a `bearer_token` field instead of an AWS `role_arn`. Enables this module to manage ArgoCD cluster secrets for non-AWS Kubernetes clusters (UpCloud UKS, Scaleway Kapsule, Hetzner via Cloudfleet, Exoscale SKS).

## Why

The companion producer module `terraform-aws-k8s-argocd-cluster-secret` is AWS-specific (uses `kops_kube_config` data source, writes `role_arn`). For non-AWS clusters, downstream users write a parallel SM secret at `argocd/clusters/<name>` containing `bearer_token` + `cluster_ca_certificate` + `host`.

The pre-existing template branched only on `argocd_cluster_secret == true`, falling through to a single AWS-only `awsAuthConfig` block. ESO failed with `map has no entry for key "role_arn"` on every non-AWS secret.

## Change

Adds a third template branch using Sprig `hasKey`:

```
{{- if eq (index . "argocd_cluster_secret") "true" }}
  # ArgoCD self-cluster
{{- else if hasKey . "bearer_token" }}
  # bearerToken + caData
{{- else }}
  # awsAuthConfig + roleARN (existing AWS path)
{{- end }}
```

Backwards compatible — existing AWS secrets fall through to the unchanged AWS branch.

## Test plan

- [x] AWS path renders unchanged (verified template diff).
- [ ] Non-AWS path syncs an ArgoCD cluster Secret with `bearerToken` + `caData` from a Scaleway Kapsule kubeconfig.
- [ ] Multi-cluster ApplicationSets in `argocd-applications` select the new cluster via `Provider=scaleway` tag.